### PR TITLE
Update Renovate config and add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,5 @@
 * @mboldi
 
-backend/ @KOliver94
 .github/ @KOliver94
+backend/ @KOliver94
 docker-compose*.yml @KOliver94

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+* @mboldi
+
+backend/ @KOliver94
+.github/ @KOliver94
+docker-compose*.yml @KOliver94

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -108,6 +108,20 @@
       ]
     },
     {
+      "description": "Docker base images (disable minor/patch)",
+      "matchManagers": [
+        "dockerfile",
+        "docker-compose"
+      ],
+      "matchUpdateTypes": [
+        "minor",
+        "patch",
+        "pin",
+        "digest"
+      ],
+      "enabled": false
+    },
+    {
       "description": "Docker base images",
       "matchManagers": [
         "dockerfile",

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -68,34 +68,11 @@
       "automerge": true
     },
     {
-      "description": "Frontend major updates",
+      "description": "Frontend (disabled during refactor)",
       "matchFileNames": [
         "frontend/**"
       ],
-      "matchUpdateTypes": [
-        "major"
-      ],
-      "additionalBranchPrefix": "frontend/",
-      "addLabels": [
-        "frontend"
-      ],
-      "groupName": "frontend major"
-    },
-    {
-      "description": "Frontend minor and patch updates",
-      "matchFileNames": [
-        "frontend/**"
-      ],
-      "matchUpdateTypes": [
-        "minor",
-        "patch",
-        "digest"
-      ],
-      "additionalBranchPrefix": "frontend/",
-      "addLabels": [
-        "frontend"
-      ],
-      "groupName": "frontend non-major"
+      "enabled": false
     },
     {
       "description": "GitHub Actions",


### PR DESCRIPTION
## Summary
- Disable minor, patch, pin, and digest updates for Docker base images - only major version bumps will create PRs
- Add CODEOWNERS file (backend, .github, docker-compose → @KOliver94, everything → @mboldi)
- Temporarily disable Renovate updates for frontend while it's being refactored