### PR TITLE
Rename itext7-core dependency to itext-core

### DIFF
--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -30,7 +30,7 @@ repositories {
 
 dependencies {
     implementation("com.github.ben-manes.caffeine:caffeine:3.2.3")
-    implementation("com.itextpdf:itext7-core:9.5.0")
+    implementation("com.itextpdf:itext-core:9.5.0")
     implementation("org.mapstruct:mapstruct:1.6.3")
     implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:3.0.2")
     implementation("org.springframework.boot:spring-boot-starter-actuator")


### PR DESCRIPTION
## Summary
- Rename `com.itextpdf:itext7-core` to `com.itextpdf:itext-core` following the official artifact rename on Maven Central
- The "7" was dropped from the artifact name as the library has moved through major versions 8 and 9
- No code changes needed - same version (9.5.0), same functionality